### PR TITLE
Added the ability to have absolute Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,13 @@ Require the build artifact via a sprockets directive
 // app/assets/javascripts/application.js
 //= require ./generated/webpack-application-bundle
 ```
+
+Options and Defaults
+---------------------
+
+```javascript
+{
+  // The path that you give as the destination will be taken as absolute if this flag is set 
+  absoluteMappingPaths : false
+}
+```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function WebpackCopyAfterBuildPlugin(mappings, options) {
 
 WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
   var mappings = this._mappings;
-  var options  = this._mappings;
+  var options  = this._options;
 
   compiler.plugin("done", function(stats) {
     var statsJson = stats.toJson();

--- a/index.js
+++ b/index.js
@@ -28,10 +28,12 @@ WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
 
         var chunkFilename = chunk.files[0];
         var from = outputPath + "/" + chunkFilename;
-        var to = outputPath + "/" + mapping;
+        var to;
 
-        if( options.absoluteMappingPaths === true ){
+        if( options.absoluteMappingPaths){
           to = mapping;
+        } else {
+          to = outputPath + "/" + mapping;
         }
 
         fse.copySync(from, to);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var fse = require("fs-extra");
 
-function WebpackCopyAfterBuildPlugin(mappings) {
+function WebpackCopyAfterBuildPlugin(mappings, options) {
   this._mappings = mappings || {};
+  this._options = options || {};
 }
 
 WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
@@ -28,6 +29,10 @@ WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
         var chunkFilename = chunk.files[0];
         var from = outputPath + "/" + chunkFilename;
         var to = outputPath + "/" + mapping;
+
+        if( options.absoluteMappingPaths === true ){
+          to = mapping;
+        }
 
         fse.copySync(from, to);
       }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function WebpackCopyAfterBuildPlugin(mappings, options) {
 
 WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
   var mappings = this._mappings;
+  var options  = this._mappings;
 
   compiler.plugin("done", function(stats) {
     var statsJson = stats.toJson();

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ WebpackCopyAfterBuildPlugin.prototype.apply = function(compiler) {
         var from = outputPath + "/" + chunkFilename;
         var to;
 
-        if( options.absoluteMappingPaths){
+        if( options.absoluteMappingPaths ){
           to = mapping;
         } else {
           to = outputPath + "/" + mapping;


### PR DESCRIPTION
Hey @rupurt, thanks for your work on this plugin it was almost exactly what I needed just had to add one small thing. 
Created an options object containing an attribute `absoluteMappingPaths` which when set to true the plugin will now assume that you are giving it the absolute path to the destination. This gives the plugin a bit more flexibility.